### PR TITLE
generate_bindings.cr: Fix Process.run for crystal 0.24

### DIFF
--- a/support/generate_bindings.cr
+++ b/support/generate_bindings.cr
@@ -224,8 +224,8 @@ platforms.each_with_index do |platform, idx|
     args: args,
     env: env,
     shell: false,
-    output: true,
-    error: true,
+    output: STDOUT,
+    error: STDERR,
   )
 
   unless bindgen.success?


### PR DESCRIPTION
Could you generate the bindings and update the branch `master-ready-to-use` as `qt 5.10` is currently missing?