### PR TITLE
Add upstream Bindgen features

### DIFF
--- a/config/processors_and_generators.yml
+++ b/config/processors_and_generators.yml
@@ -5,6 +5,7 @@ processors:
   - copy_structs # Copy structures as marked
   - macros # Support for macro mapping
   - functions # Support C-style functions
+  - instance_properties # Add property methods for public instance members
   - filter_methods # Throw out filtered methods
   - auto_container_instantiation
   - instantiate_containers # Actually instantiate containers
@@ -12,6 +13,7 @@ processors:
   - qt # Qt specifics
   # Preliminary generation processors:
   - crystal_wrapper # Create Crystal wrappers
+  - block_overloads # Add type tags for block overloads
   - virtual_override # Allow overriding C++ virtual methods
   - cpp_wrapper # Create C++ <-> C wrappers
   - crystal_binding # Create `lib` bindings for the C wrapper

--- a/samples/virtual_override.cr
+++ b/samples/virtual_override.cr
@@ -8,12 +8,16 @@ class MyLabel < Qt::Label
   #    Then, write the implementation - Like normal
   def mouse_press_event(event : Qt::MouseEvent) : Void
     self.text = "Event: Press\n#{event.buttons}"
+    # 3. Refer to the base class implementation using `#superclass`.
+    #    **DO NOT** use `super` here - it will crash!
+    superclass.mouse_press_event(event)
   end
 
   # You can also rely on Crystals type-deduction, and leave out the argument
-  # types.  Same goes for return type.
-  def mouse_release_event(event)
+  # types.  The return type must still match.
+  def mouse_release_event(event) : Void
     self.text = "Event: Release\n#{event.buttons}"
+    superclass.mouse_release_event(event)
   end
 end
 


### PR DESCRIPTION
Inserts the `InstanceProperties` and `BlockOverloads` processors. The former should have no effects because the `Qt::StyleOption` hierarchy isn't in yet.

The prebuilt bindings still need to be regenerated after this.

Should partially fix #33.