### PR TITLE
Add types Qt::Pen, Qt::PenCapStyle and Qt::PenJoinStyle

### DIFF
--- a/config/classes.yml
+++ b/config/classes.yml
@@ -98,6 +98,7 @@ classes:
   QGraphicsRectItem: GraphicsRectItem
   QGraphicsSimpleTextItem: GraphicsSimpleTextItem
   QGraphicsPixmapItem: GraphicsPixmapItem
+  QPen: Pen
   QBrush: Brush
   QColor: Color
   QEvent: Event

--- a/config/enums.yml
+++ b/config/enums.yml
@@ -40,6 +40,8 @@ enums:
   "Qt::SizeMode": SizeMode
   "Qt::ClipOperation": ClipOperation
   "Qt::PenStyle": PenStyle
+  "Qt::PenCapStyle": PenCapStyle
+  "Qt::PenJoinStyle": PenJoinStyle
   "Qt::ScreenOrientations": ScreenOrientations
   "Qt::ArrowType": ArrowType
   "Qt::CaseSensitivity": CaseSensitivity

--- a/config/types.yml
+++ b/config/types.yml
@@ -112,6 +112,7 @@ types: # Type rewrite rules
   QIconPrivate: { ignore: true }
   "QPixmap::DataPtr": { ignore: true }
   "QBrush::DataPtr": { ignore: true }
+  QPenPrivate: { ignore: true }
 
   # Waiting for a reasonable pass-through implementation of QByteArray
   "QList<QByteArray>": { ignore: true }


### PR DESCRIPTION
These types are missing for some reason, a real limitation when using a `Qt::Painter`