### PR TITLE
Qt::Application resets numeric locale to "C"

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ Qt::Application.exec
 
 ![hello-qt](https://raw.githubusercontent.com/Papierkorb/qt5.cr/master/images/hello-qt.png)
 
+## Locale
+
+By default Qt sets the locale to the system locale when an application
+class (like `Qt::Application`) is instantiated. However, this causes
+stdlib Crystal functions like `to_f` to behave unexpectedly, e.g.,
+using a different character as decimal separator (also see the discussion
+of this [PR](https://github.com/Papierkorb/qt5.cr/pull/51)).
+Therefore, in contrast to the behaviour of the C++ classes of Qt,
+`qt5.cr` resets the numeric locale to "C" after creating an
+application class instance (this follows an [advice from Qt
+itself](https://doc.qt.io/qt-5/qcoreapplication.html#locale-settings)).
+
 # Developer perspective
 
 ## Generating the bindings

--- a/config/find_paths.yml
+++ b/config/find_paths.yml
@@ -106,3 +106,11 @@ find_paths:
   #     variable: CLANG_VERSION
   #     command: "% --version"
   #     regex: "^clang version ([0-9]+)."
+  EXT_INCLUDES:
+    kind: Directory
+    optional: false
+    list:
+      separator: " -I"
+      template: "%"
+    try:
+      - "%/ext"

--- a/config/functions.yml
+++ b/config/functions.yml
@@ -1,3 +1,5 @@
 functions:
   "^qVersion$":
     destination: "::"
+  "^qt5cr_reset_numeric_locale":
+    destination: "::"

--- a/ext/locale_helper.hpp
+++ b/ext/locale_helper.hpp
@@ -1,0 +1,9 @@
+#ifdef Q_OS_UNIX
+#include <clocale>
+#endif
+
+void qt5cr_reset_numeric_locale() {
+#ifdef Q_OS_UNIX
+  std::setlocale(LC_NUMERIC, "C");
+#endif
+}

--- a/qt.yml
+++ b/qt.yml
@@ -40,10 +40,12 @@ parser: # Clang parser configuration
     - QtCore/QtCore
     - QtGui/QtGui
     - QtWidgets/QtWidgets
+    - "locale_helper.hpp"
   includes:
     - "{QT_INCLUDE_DIR}/"
     - "{QT_INCLUDE_DIR}/QtCore/"
     - "{QT_INCLUDE_DIR}/QtGui/"
     - "{QT_INCLUDE_DIR}/QtWidgets/"
     - "{LLVM_INCLUDES}"
+    - "{EXT_INCLUDES}"
 

--- a/src/qt5/application.cr
+++ b/src/qt5/application.cr
@@ -5,6 +5,7 @@ module Qt
 
     def initialize
       @unwrap = Binding.bg_QApplication__CONSTRUCT_int_R_char_XX_int(pointerof(@argc), @argv, QT_VERSION)
+      Qt.qt5cr_reset_numeric_locale
     end
   end
 end


### PR DESCRIPTION
This is necessary (and [adviced by Qt](https://doc.qt.io/qt-5/qcoreapplication.html#locale-settings)) because Qt sets the locale to
the system default when creating an application object. However,
Crystal functions like `to_f` depend on the locale being set to "C" by
default.

Because the locale is Unix-specific the reset is done by adding an
additional C helper function, which is called from
`Qt::Application#initialize`.

For instance, the following example would raise an error with my system locale (de_DE):

```
require "qt5"

"4.2".to_f   # works
qapp = Qt::Application.new
"4.2".to_f   # fails because the locale has been changed such the decimal separator is "," now and not "."
```

Because the constant `LC_NUMERIC` is system dependent (although it's probably always `1` nowadays, but you can't be sure), we add a new C function (instead of just a `lib`-binding to `setlocale` from the Crystal side). This makes everything a little bit more complicated because we need to make sure that bindgen finds the new function and generates a binding for it.