### PR TITLE
Add bindings to QLocale

### DIFF
--- a/config/classes.yml
+++ b/config/classes.yml
@@ -171,3 +171,4 @@ classes:
   QListWidget: ListWidget
   QListWidgetItem: ListWidgetItem
   QMargins: Margins
+  QLocale: Locale

--- a/config/enums.yml
+++ b/config/enums.yml
@@ -267,3 +267,15 @@ enums:
   "QListView::ResizeMode": ListView::ResizeMode
   "QListView::LayoutMode": ListView::LayoutMode
   "QListView::ViewMode": ListView::ViewMode
+  "QLocale::Country": Locale::Country
+  "QLocale::CurrencySymbolFormat": Locale::CurrencySymbolFormat
+  "QLocale::DataSizeFormat": Locale::DataSizeFormat
+  "QLocale::DataSizeFormats": Locale::DataSizeFormats
+  "QLocale::FloatingPointPrecisionOption": Locale::FloatingPointPrecisionOption
+  "QLocale::FormatType": Locale::FormatType
+  "QLocale::Language": Locale::Language
+  "QLocale::MeasurementSystem": Locale::MeasurementSystem
+  "QLocale::NumberOption": Locale::NumberOption
+  "QLocale::NumberOptions": Locale::NumberOptions
+  "QLocale::QuotationStyle": Locale::QuotationStyle
+  "QLocale::Script": Locale::Script

--- a/config/enums.yml
+++ b/config/enums.yml
@@ -1,4 +1,5 @@
 enums:
+  "Qt::DayOfWeek": DayOfWeek
   "Qt::CheckState": CheckState
   "Qt::ConnectionType": ConnectionType
   "Qt::TimerType": TimerType

--- a/config/processors_and_generators.yml
+++ b/config/processors_and_generators.yml
@@ -9,8 +9,8 @@ processors:
   - instance_properties # Add property methods for public instance members
   - filter_methods # Throw out filtered methods
   - auto_container_instantiation
-  - instantiate_containers # Actually instantiate containers
   - enums # Add enums
+  - instantiate_containers # Actually instantiate containers
   - qt # Qt specifics
   # Preliminary generation processors:
   - crystal_wrapper # Create Crystal wrappers


### PR DESCRIPTION
When investigating the reset-locale problem (see PR #51) the first try was to use `QLocale`. This did not work out as hoped because I did not find a way to reset the numeric locale. However, the bindings to this class seem to work well, so maybe it is of use for someone.