### PR TITLE
More pass by value

### DIFF
--- a/config/classes.yml
+++ b/config/classes.yml
@@ -170,6 +170,7 @@ classes:
   QStyleOptionGraphicsItem: StyleOptionGraphicsItem
   QListView: ListView
   QSize: Size
+  QSizeF: SizeF
   QListWidget: ListWidget
   QListWidgetItem: ListWidgetItem
   QMargins: Margins

--- a/config/deprecated.yml
+++ b/config/deprecated.yml
@@ -38,9 +38,6 @@ QCoreApplication:
 QDir:
   ignore_methods:
   - addResourceSearchPath
-QLineF:
-  ignore_methods:
-  - angle
 QMimeData:
   ignore_methods:
   - trUtf8

--- a/config/types.yml
+++ b/config/types.yml
@@ -43,22 +43,71 @@ types: # Type rewrite rules
   QSessionManager:
     pass_by: Reference
     from_cpp: "(%)"
-  QPoint: # Manual implementation with a structure copy.
+  QPoint:
     copy_structure: true
     binding_type: QPoint
-    generate_binding: false # Wrap this one manually
-    generate_wrapper: false
-    # As we're not generating a wrapper, it won't set the `crystal_type` by
-    # itself.
-    crystal_type: Point
+    generate_binding: true
+    generate_wrapper: true
     pass_by: Value
+    kind: Struct
   QPointF:
     copy_structure: true
     binding_type: QPointF
-    generate_binding: false
-    generate_wrapper: false
+    generate_binding: true
+    generate_wrapper: true
     crystal_type: PointF
     pass_by: Value
+    kind: Struct
+  QSize:
+    copy_structure: true
+    binding_type: QSize
+    generate_binding: true
+    generate_wrapper: true
+    crystal_type: Size
+    pass_by: Value
+    kind: Struct
+    ignore_methods:
+      - toCGSize
+  QSizeF:
+    copy_structure: true
+    binding_type: QSizeF
+    generate_binding: true
+    generate_wrapper: true
+    crystal_type: SizeF
+    pass_by: Value
+    kind: Struct
+  QLine:
+    copy_structure: true
+    binding_type: QLine
+    generate_binding: true
+    generate_wrapper: true
+    crystal_type: Line
+    pass_by: Value
+    kind: Struct
+  QLineF:
+    copy_structure: true
+    binding_type: QLineF
+    generate_binding: true
+    generate_wrapper: true
+    crystal_type: LineF
+    pass_by: Value
+    kind: Struct
+  QRect:
+    copy_structure: true
+    binding_type: QRect
+    generate_binding: true
+    generate_wrapper: true
+    crystal_type: Rect
+    pass_by: Value
+    kind: Struct
+  QRectF:
+    copy_structure: true
+    binding_type: QRectF
+    generate_binding: true
+    generate_wrapper: true
+    crystal_type: RectF
+    pass_by: Value
+    kind: Struct
   "QPainter::PixmapFragment":
     ignore: true
     # copy_structure: true
@@ -145,9 +194,6 @@ types: # Type rewrite rules
   CGRect: {ignore: true}
   CFURLRef: {ignore: true}
   NSURL: {ignore: true}
-  QSize:
-    ignore_methods:
-      - toCGSize
   QListWidgetItem:
     ignore_methods:
       - "operator<"

--- a/ext/bindgen_helper.hpp
+++ b/ext/bindgen_helper.hpp
@@ -105,10 +105,16 @@ struct CrystalProc {
   }
 };
 
+/// A simple wrapper around a non-pointer type that allows a single
+/// dereference operation.
 template <typename T>
-struct CrystalGCWrapper: public T, public gc_cleanup
-{
-  using T::T;
+struct bg_deref {
+  T data;
+
+  template<typename... Args>
+  bg_deref(Args&&... args) : data(std::forward<Args>(args)...) {}
+
+  T operator*() && { return std::move(data); }
 };
 
 #endif // __cplusplus

--- a/spec/qt/line_spec.cr
+++ b/spec/qt/line_spec.cr
@@ -1,0 +1,35 @@
+require "../spec_helper"
+
+describe Qt::Line do
+  describe "#p1" do
+    context "on a null line" do
+      line = Qt::Line.new
+      it "returns (0,0)" do
+        line.p1.should eq(Qt::Point.new(0, 0))
+      end
+    end
+
+    context "on a non-null line" do
+      line = Qt::Line.new(1, 2, 3, 4)
+      it "returns the first point" do
+        line.p1.should eq(Qt::Point.new(1, 2))
+      end
+    end
+  end
+
+  describe "#p2" do
+    context "on a null line" do
+      line = Qt::Line.new
+      it "returns (0,0)" do
+        line.p2.should eq(Qt::Point.new(0, 0))
+      end
+    end
+
+    context "on a non-null line" do
+      line = Qt::Line.new(1, 2, 3, 4)
+      it "returns the second point" do
+        line.p2.should eq(Qt::Point.new(3, 4))
+      end
+    end
+  end
+end

--- a/spec/qt/point_spec.cr
+++ b/spec/qt/point_spec.cr
@@ -1,0 +1,24 @@
+require "../spec_helper"
+
+describe Qt::Point do
+  describe "#+" do
+    p = Qt::Point.new(1, 2)
+    q = Qt::Point.new(3, 4)
+    it "returns the sum of the two points" do
+      r = p + q
+      r.should eq(Qt::Point.new(4, 6))
+    end
+  end
+
+  describe "#transposed" do
+    p = Qt::Point.new(1, 2)
+    it "should return a new point with x and y swapped" do
+      r = p.transposed
+      r.should eq(Qt::Point.new(2, 1))
+    end
+
+    it "should not change the point itself" do
+      p.should eq(Qt::Point.new(1, 2))
+    end
+  end
+end

--- a/src/qt5/point.cr
+++ b/src/qt5/point.cr
@@ -1,21 +1,8 @@
 module Qt
-  # Describes a 2D-point in an unknown space.  Manual wrapper class for the
-  # Qt types `QPoint` and `QPointF`.  See `Point` and `PointF` for easy use.
-  struct PointBase(T, B)
-    getter unwrap : B
-
-    def to_unsafe : B
-      @unwrap
-    end
-
-    def initialize(x = 0, y = 0)
-      @unwrap = B.new(xp: T.new(x), yp: T.new(y))
-    end
-
-    def initialize(@unwrap : B)
-    end
-
-    {% for field in %i[ x y ].map(&.id) %}
+  # Implements a few functions directly in Crystal. This should be a
+  # little bit faster than going through the call to C++.
+  module PointMethods(T)
+    {% for field in %i[x y].map(&.id) %}
       # Returns the {{ field }} value
       def {{ field }} : T
         @unwrap.{{ field }}p
@@ -93,8 +80,12 @@ module Qt
   end
 
   # A 2D point with integer (`Int32`) accuracy.
-  alias Point = PointBase(Int32, Binding::QPoint)
+  struct Point
+    include PointMethods(Int32)
+  end
 
   # A 2D point with floating-point (`Float64`) accuracy.
-  alias PointF = PointBase(Float64, Binding::QPointF)
+  struct PointF
+    include PointMethods(Float64)
+  end
 end

--- a/src/qt5/point.cr
+++ b/src/qt5/point.cr
@@ -71,11 +71,11 @@ module Qt
     end
 
     def to_s(io)
-      io << "#{x}, #{y}"
+      io << x << ", " << y
     end
 
     def inspect(io)
-      io << "<Point: #{x}, #{y}>"
+      io << "<" << self.class.name << ": " << x << ", " << y << ">"
     end
   end
 

--- a/src/qt5/rect.cr
+++ b/src/qt5/rect.cr
@@ -1,7 +1,7 @@
 module Qt
   struct Rect
     def to_s(io)
-      io << "#{width}x#{height} @ #{x},#{y}"
+      io << width << "x" << height << " @ " << x << "," << y
     end
 
     def inspect(io)
@@ -13,7 +13,7 @@ module Qt
 
   struct RectF
     def to_s(io)
-      io << "#{width}x#{height} @ #{x},#{y}"
+      io << width << "x" << height << " @ " << x << "," << y
     end
 
     def inspect(io)

--- a/src/qt5/rect.cr
+++ b/src/qt5/rect.cr
@@ -1,5 +1,5 @@
 module Qt
-  class Rect
+  struct Rect
     def to_s(io)
       io << "#{width}x#{height} @ #{x},#{y}"
     end
@@ -11,7 +11,7 @@ module Qt
     end
   end
 
-  class RectF
+  struct RectF
     def to_s(io)
       io << "#{width}x#{height} @ #{x},#{y}"
     end


### PR DESCRIPTION
Now several types are passed by value, greatly reducing memory-management-work. Furthermore the wrappers are now generated automatically, so all methods are supported (in contrast to the former manual wrapper around `Qt::Point` and `Qt::PointF`). This includes the types `QPoint`, `QSize`, `QRect` and `QLine` and der `*F` counterparts.

I kept some of the manual methods for `QPoint` because they should be even faster (they can be inlined and do not have to go through the c++ binding).

This requires [bindgen PR #121](https://github.com/Papierkorb/bindgen/pull/121) to merged first.